### PR TITLE
✨[Feat] 로그인 상태에서는 헤더의 로그인 / 회원가입 버튼이 마이페이지 버튼으로 바뀌게끔 기능 구현 #112

### DIFF
--- a/open-market/src/App.tsx
+++ b/open-market/src/App.tsx
@@ -1,30 +1,38 @@
 import { Global, css } from "@emotion/react";
+import { useEffect } from "react";
 import { HelmetProvider, HelmetServerState } from "react-helmet-async";
 import { RouterProvider } from "react-router-dom";
-import { RecoilRoot } from "recoil";
+import { useSetRecoilState } from "recoil";
 import router from "./routes";
 import { Common } from "./styles/common";
 
-import { QueryClient, QueryClientProvider } from "react-query"; // 추가
+import { QueryClient, QueryClientProvider } from "react-query";
 
-const queryClient = new QueryClient(); // 추가
+import { loggedInState } from "@/states/authState";
+
+const queryClient = new QueryClient();
 
 function App() {
 	const helmetContext: { helmet: HelmetServerState } = {
 		helmet: {} as HelmetServerState,
 	};
 
+	const setLoggedIn = useSetRecoilState(loggedInState);
+
+	useEffect(() => {
+		const token = localStorage.getItem("accessToken");
+		setLoggedIn(!!token);
+	}, [setLoggedIn]);
+
 	return (
 		<QueryClientProvider client={queryClient}>
 			<HelmetProvider context={helmetContext}>
-				<RecoilRoot>
-					<Global
-						styles={css`
-							${Common.reset}
-						`}
-					/>
-					<RouterProvider router={router} />
-				</RecoilRoot>
+				<Global
+					styles={css`
+						${Common.reset}
+					`}
+				/>
+				<RouterProvider router={router} />
 			</HelmetProvider>
 		</QueryClientProvider>
 	);

--- a/open-market/src/layout/Header.tsx
+++ b/open-market/src/layout/Header.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { loggedInState } from "../states/authState";
 
 const StyledHeader = styled.header`
 	display: flex;
@@ -104,12 +106,7 @@ const MyPageButton = styled(Link)`
 `;
 
 const Header = () => {
-	const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-	useEffect(() => {
-		const token = localStorage.getItem("accessToken"); // 예시로 accessToken 사용
-		setIsLoggedIn(!!token);
-	}, []);
+	const loggedIn = useRecoilValue(loggedInState);
 
 	return (
 		<StyledHeader>
@@ -127,7 +124,7 @@ const Header = () => {
 					<FileUploadIcon fontSize="small" />
 					업로드
 				</UploadButton>
-				{isLoggedIn ? (
+				{loggedIn ? (
 					<MyPageButton to="/mypage">마이페이지</MyPageButton>
 				) : (
 					<LoginButton to="/signin">로그인 / 회원가입</LoginButton>

--- a/open-market/src/layout/Header.tsx
+++ b/open-market/src/layout/Header.tsx
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import { Link } from "react-router-dom";
@@ -89,7 +90,27 @@ const LoginButton = styled(Link)`
 	}
 `;
 
+const MyPageButton = styled(Link)`
+	padding: 0.5rem 1rem;
+	background-color: #6c757d;
+	border: none;
+	border-radius: 20px;
+	color: white;
+	cursor: pointer;
+
+	&:hover {
+		background-color: #5a6268;
+	}
+`;
+
 const Header = () => {
+	const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+	useEffect(() => {
+		const token = localStorage.getItem("accessToken"); // 예시로 accessToken 사용
+		setIsLoggedIn(!!token);
+	}, []);
+
 	return (
 		<StyledHeader>
 			<Logo>
@@ -106,7 +127,11 @@ const Header = () => {
 					<FileUploadIcon fontSize="small" />
 					업로드
 				</UploadButton>
-				<LoginButton to="/signin">로그인 / 회원가입</LoginButton>
+				{isLoggedIn ? (
+					<MyPageButton to="/mypage">마이페이지</MyPageButton>
+				) : (
+					<LoginButton to="/signin">로그인 / 회원가입</LoginButton>
+				)}
 			</ActionGroup>
 		</StyledHeader>
 	);

--- a/open-market/src/main.tsx
+++ b/open-market/src/main.tsx
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom/client";
 import { Toaster } from "react-hot-toast";
 import App from "./App";
 import "./index.css";
+import { RecoilRoot } from "recoil";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
-		<Toaster />
-		<App />
+		<RecoilRoot>
+			<Toaster />
+			<App />
+		</RecoilRoot>
 	</React.StrictMode>,
 );

--- a/open-market/src/pages/SignIn.tsx
+++ b/open-market/src/pages/SignIn.tsx
@@ -3,8 +3,12 @@ import React, { useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link, useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
+import { useRecoilState } from "recoil";
+import { loggedInState } from "../states/authState";
 
 function SignIn() {
+	const [loggedIn, setLoggedIn] = useRecoilState(loggedInState);
+
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const navigate = useNavigate();
@@ -32,6 +36,7 @@ function SignIn() {
 
 				// 로그인 성공 이후 홈 페이지로 이동.
 				toast.success("로그인 성공!");
+				setLoggedIn(true);
 				navigate("/");
 			}
 		} catch (error: any) {

--- a/open-market/src/states/authState.ts
+++ b/open-market/src/states/authState.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const loggedInState = atom({
+	key: "loggedInState",
+	default: false,
+});


### PR DESCRIPTION
<!-- 
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X 
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->


## 작업사항
<!-- 작업한 내용 작성 -->
- 로컬 스토리지 확인후 로그인 정보가 있다면 헤더의 '로그인 / 회원가입' 버튼이 '마이페이지' 버튼으로 바뀌어 표시되게끔 구현
- 로그인 이후 메인 페이지 이동시 바로 로그인 / 회원가입 버튼이 마이페이지 버튼으로 바뀌지 않는 문제 해결
    - states 폴더 생성 후 authState.ts 파일 생성, 로그인 상태 전역 관리 코드 추가.
    - App.tsx에 전역 상태 관리 코드 추가
    - App.tsx의 recoilRoot 코드 main.tsx 로 이동(에러 해결을 위함)

## 미리보기 및 사용방법
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->\
### App.tsx
![image](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/b97a497d-865a-4f00-9309-351f69905392)

### main.tsx
![image](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/2046e08e-ce44-4f8d-85f0-ece21bdc4ec5)

![Nov-30-2023 13-57-26](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/a5059f80-7081-4711-87f1-ffff35367f79)



## 기타
<!-- 필요한 경우 작성 -->


## 작성일
<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->
2023.11.30
