### PR TITLE
✨[Feature] index 페이지 카테고리 필터 기능 구현 #193

### DIFF
--- a/open-market/src/layout/Header.tsx
+++ b/open-market/src/layout/Header.tsx
@@ -22,6 +22,7 @@ import { KeyboardEvent, useEffect, useState } from "react";
 
 import axiosInstance from "@/api/instance";
 import {
+	categoryKeywordState,
 	fetchproductListState,
 	productListState,
 	searchKeywordState,
@@ -66,6 +67,7 @@ const Header = () => {
 	const [_, setSearchedProductList] = useRecoilState<Product[]>(
 		searchedProductListState,
 	);
+	const [__, setCategoryFilter] = useRecoilState<string>(categoryKeywordState);
 
 	const [loggedIn, setLoggedIn] = useRecoilState(loggedInState);
 	const navigate = useNavigate();
@@ -145,7 +147,13 @@ const Header = () => {
 		<AppBar position="static" color="default" elevation={1}>
 			<Toolbar>
 				<Logo>
-					<Link to="/" onClick={() => setSearchKeyword("")}>
+					<Link
+						to="/"
+						onClick={() => {
+							setSearchKeyword("");
+							setCategoryFilter("all");
+						}}
+					>
 						<img
 							src={logoImage}
 							alt="모디 로고"

--- a/open-market/src/pages/product/ProductEdit.tsx
+++ b/open-market/src/pages/product/ProductEdit.tsx
@@ -213,7 +213,7 @@ function ProductEdit() {
 								>
 									{category && category.length !== 0
 										? category.map((item) => (
-												<option key={item.code} value={item.code}>
+												<option key={item.code} value={item.value}>
 													{item.value}
 												</option>
 										  ))

--- a/open-market/src/pages/product/ProductRegistration.tsx
+++ b/open-market/src/pages/product/ProductRegistration.tsx
@@ -200,7 +200,7 @@ function ProductRegistration() {
 										</option>
 										{category && category.length !== 0
 											? category.map((item) => (
-													<option key={item.code} value={item.code}>
+													<option key={item.code} value={item.value}>
 														{item.value}
 													</option>
 											  ))

--- a/open-market/src/states/productListState.ts
+++ b/open-market/src/states/productListState.ts
@@ -28,3 +28,8 @@ export const searchedProductListState = atom<Product[]>({
 	key: "searchProductListState",
 	default: [],
 });
+
+export const categoryKeywordState = atom<string>({
+	key: "categoryKeywordState",
+	default: "all",
+});

--- a/open-market/src/utils/filterProductList.ts
+++ b/open-market/src/utils/filterProductList.ts
@@ -18,3 +18,20 @@ export function searchProductList({
 	});
 	return filteredList;
 }
+
+export function categoryFilterProductList({
+	category,
+	productList,
+}: {
+	category: string;
+	productList: Product[];
+}) {
+	const filteredList = productList.filter((product) => {
+		const productCategory = product.extra?.category!;
+		if (productCategory.includes(category)) {
+			return true;
+		}
+		return false;
+	});
+	return filteredList;
+}


### PR DESCRIPTION
<!-- 
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X 
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->


## 작업사항
<!-- 작업한 내용 작성 -->
- 상품 등록/수정 페이지의 카테고리 옵션 value를 code에서 value로 수정
- 인덱스 페이지 카테고리 선택 시 해당하는 카테고리만 보이도록 필터링 구현
- 검색 키워드와 카테고리 필터가 함께 있을 경우 필터링 된 리스트에서 키워드 서치
- 상품을 클릭한 뒤(디테일 페이지 이동 후) 뒤로가기를 눌러도 카테고리 필터링이 해제되지 않도록 구현
- 로고 클릭 시 카테고리 필터 초기화
-  카테고리 항목에 전체 보기 항목 추가

## 미리보기 및 사용방법
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
![Dec-07-2023 17-15-23](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/43366461/5941f449-8be8-4958-9703-eccfe655e464)


## 기타
<!-- 필요한 경우 작성 -->
카테고리 필터를 전역 상태로 관리

## 작성일
<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->
2023.12.07
