### PR TITLE
🐛[Fix] 회원정보 변경시 로그인이 되지 않는 문제 #180

### DIFF
--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -8,8 +8,8 @@ function UserEdit() {
 	const [userData, setUserData] = useState({
 		email: "",
 		name: "",
-		// password: "",
-		// confirmPassword: "",
+		password: "",
+		confirmPassword: "",
 		phone: "",
 		extra: {
 			profileImage: "",
@@ -45,8 +45,8 @@ function UserEdit() {
 								...response.data.item.extra?.terms, // API 응답의 terms
 							},
 						},
-						// password: "", // 비밀번호 필드 초기화
-						// confirmPassword: "", // 비밀번호 확인 필드 초기화
+						password: "", // 비밀번호 필드 초기화
+						confirmPassword: "", // 비밀번호 확인 필드 초기화
 					};
 					setUserData(fetchedData);
 				}
@@ -62,15 +62,26 @@ function UserEdit() {
 	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
 
+		// 비밀번호 길이 확인
+		if (userData.password && userData.password.length < 8) {
+			toast.error("비밀번호는 8자 이상이어야 합니다.");
+			return;
+		}
+
 		// 비밀번호 확인 로직
-		// if (userData.password !== userData.confirmPassword) {
-		// 	toast.error("비밀번호가 일치하지 않습니다.");
-		// 	return;
-		// }
+		if (userData.password !== userData.confirmPassword) {
+			toast.error("비밀번호가 일치하지 않습니다.");
+			return;
+		}
+
+		// 사용자가 비밀번호를 입력하지 않았을 경우 비밀번호 필드를 제외한 데이터로 요청
+		const payload = userData.password
+			? userData
+			: { ...userData, password: undefined, confirmPassword: undefined };
 
 		// 정보 수정 요청
 		try {
-			const response = await axiosInstance.patch(`/users/${userId}`, userData, {
+			const response = await axiosInstance.patch(`/users/${userId}`, payload, {
 				headers: {
 					Authorization: `Bearer ${accessToken}`,
 				},
@@ -179,7 +190,7 @@ function UserEdit() {
 							onChange={handleInputChange}
 						/>
 					</li>
-					{/* <li>
+					<li>
 						<label htmlFor="password">비밀번호</label>
 						<input
 							type="password"
@@ -196,7 +207,7 @@ function UserEdit() {
 							value={userData.confirmPassword}
 							onChange={handleInputChange}
 						/>
-					</li> */}
+					</li>
 					<li>
 						<label htmlFor="phone">휴대폰 번호</label>
 						<input

--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -8,8 +8,8 @@ function UserEdit() {
 	const [userData, setUserData] = useState({
 		email: "",
 		name: "",
-		password: "",
-		confirmPassword: "",
+		// password: "",
+		// confirmPassword: "",
 		phone: "",
 		extra: {
 			profileImage: "",
@@ -45,8 +45,8 @@ function UserEdit() {
 								...response.data.item.extra?.terms, // API 응답의 terms
 							},
 						},
-						password: "", // 비밀번호 필드 초기화
-						confirmPassword: "", // 비밀번호 확인 필드 초기화
+						// password: "", // 비밀번호 필드 초기화
+						// confirmPassword: "", // 비밀번호 확인 필드 초기화
 					};
 					setUserData(fetchedData);
 				}
@@ -63,10 +63,10 @@ function UserEdit() {
 		event.preventDefault();
 
 		// 비밀번호 확인 로직
-		if (userData.password !== userData.confirmPassword) {
-			toast.error("비밀번호가 일치하지 않습니다.");
-			return;
-		}
+		// if (userData.password !== userData.confirmPassword) {
+		// 	toast.error("비밀번호가 일치하지 않습니다.");
+		// 	return;
+		// }
 
 		// 정보 수정 요청
 		try {
@@ -179,7 +179,7 @@ function UserEdit() {
 							onChange={handleInputChange}
 						/>
 					</li>
-					<li>
+					{/* <li>
 						<label htmlFor="password">비밀번호</label>
 						<input
 							type="password"
@@ -196,7 +196,7 @@ function UserEdit() {
 							value={userData.confirmPassword}
 							onChange={handleInputChange}
 						/>
-					</li>
+					</li> */}
 					<li>
 						<label htmlFor="phone">휴대폰 번호</label>
 						<input

--- a/samples/dbinit.js
+++ b/samples/dbinit.js
@@ -174,7 +174,7 @@ async function registUser() {
       name: "제이지",
       phone: "01044445555",
       address: "서울시 강남구 논현동 222",
-      type: "user",
+      type: "seller",
       createdAt: getTime(-20, -60 * 30),
       updatedAt: getTime(-10, -60 * 60 * 12),
       extra: {


### PR DESCRIPTION
<!-- 
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X 
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->


## 작업사항
<!-- 작업한 내용 작성 -->
- api 상에서 회원정보 중 비밀번호를 수정시 비밀번호를 암호화 하지 않고 저장하는 문제로 인해 회원 정보 수정 이후 로그인이 되지 않는 문제 발견.
- 비밀번호를 빈칸으로 제출할 경우 비밀번호를 제외한 정보만을 수정 요청하게끔 로직 수정.
- 비밀번호 수정시에 8자 미만으로 입력할 경우 알림과 함께 거부하는 로직 추가.

## 미리보기 및 사용방법
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->

![image](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/049c9167-89a2-4d9e-9e48-0eebb1689b66)

![Dec-10-2023 19-56-17](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/91d598b7-36ac-4617-b625-78ba6d04a099)

## 기타
<!-- 필요한 경우 작성 -->


## 작성일
<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->
2023.12.10
