### PR TITLE
💄[Design] 회원정보 수정 페이지 스타일링 #242

### DIFF
--- a/open-market/src/components/AuthInput.tsx
+++ b/open-market/src/components/AuthInput.tsx
@@ -7,10 +7,11 @@ interface AuthInputProps {
 	name: string;
 	label?: string;
 	type: string;
-	defaultValue: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	defaultValue?: string;
 	placeholder?: string;
 	required?: boolean;
+	readonly?: boolean;
 }
 
 const AuthInputWrppaer = styled.div`
@@ -56,6 +57,7 @@ function AuthInput(props: AuthInputProps) {
 		onChange,
 		placeholder,
 		required,
+		readonly,
 	} = props;
 	return (
 		<AuthInputWrppaer>
@@ -68,6 +70,7 @@ function AuthInput(props: AuthInputProps) {
 				onChange={onChange}
 				placeholder={placeholder}
 				required={required}
+				readOnly={readonly}
 			/>
 		</AuthInputWrppaer>
 	);

--- a/open-market/src/layout/RootLayout.tsx
+++ b/open-market/src/layout/RootLayout.tsx
@@ -1,6 +1,6 @@
-import { Outlet, useLocation } from "react-router-dom";
-import Header from "@/layout/Header";
 import Footer from "@/layout/Footer";
+import Header from "@/layout/Header";
+import { Outlet, useLocation } from "react-router-dom";
 
 function RootLayout() {
 	const location = useLocation();

--- a/open-market/src/layout/RootLayout.tsx
+++ b/open-market/src/layout/RootLayout.tsx
@@ -4,15 +4,19 @@ import Footer from "@/layout/Footer";
 
 function RootLayout() {
 	const location = useLocation();
-	const auth = ["/signin", "/signup"];
+	const noHeaderFooterRoutes = ["/signin", "/signup", "/useredit/:userId"];
 
+	const shouldDisplayHeaderFooter = !noHeaderFooterRoutes.some((route) =>
+		location.pathname.includes(route.replace("/:userId", "")),
+	);
+    
 	return (
 		<>
-			{!auth.includes(location.pathname) && <Header />}
+			{shouldDisplayHeaderFooter && <Header />}
 			<main>
 				<Outlet />
 			</main>
-			{!auth.includes(location.pathname) && <Footer />}
+			{shouldDisplayHeaderFooter && <Footer />}
 		</>
 	);
 }

--- a/open-market/src/pages/user/MyPage.tsx
+++ b/open-market/src/pages/user/MyPage.tsx
@@ -78,6 +78,12 @@ const PersonalInfoItem = styled.div`
 	}
 `;
 
+const UserImage = styled.img`
+	width: 100%;
+	height: 100%;
+	border-radius: 50%;
+`;
+
 const Comment = styled.div`
 	position: relative;
 	display: flex;
@@ -243,7 +249,7 @@ function MyPage() {
 			<MainTitle>마이페이지</MainTitle>
 			<Article>
 				<InfoTitle>내 정보</InfoTitle>
-				<img src={profileImageUrl} alt="회원 썸네일" />
+				<UserImage src={profileImageUrl} alt="회원 썸네일" />
 				<Info>
 					<PersonalInfo>
 						<Title>회원정보</Title>

--- a/open-market/src/pages/user/SignUp.tsx
+++ b/open-market/src/pages/user/SignUp.tsx
@@ -96,6 +96,7 @@ const Fieldset = styled.fieldset`
 		}
 	}
 `;
+
 const StyledCheckbox = styled(Checkbox)`
 	margin: 0;
 	padding: 0;

--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -1,9 +1,167 @@
+import AuthInput from "@/components/AuthInput";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { Common } from "@/styles/common";
 import { axiosInstance } from "@/utils";
+import styled from "@emotion/styled";
+import Checkbox from "@mui/material/Checkbox";
 import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast from "react-hot-toast";
 import { Link, useNavigate } from "react-router-dom";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+
+const Title = styled.h2`
+	${Common.a11yHidden};
+`;
+
+const Backgroud = styled.section`
+	width: 100vw;
+	height: 100vh;
+	background-color: ${Common.colors.black};
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+`;
+
+const Form = styled.form`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 10px;
+	background-color: ${Common.colors.white};
+
+	width: 506px;
+	padding: ${Common.space.spacingLg};
+	box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+	border-radius: 10px;
+`;
+
+const Fieldset = styled.fieldset`
+	width: 380px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 5px;
+	legend {
+		text-align: center;
+		margin: 28px auto;
+
+		font-weight: ${Common.font.weight.bold};
+		font-size: 32px;
+
+		color: ${Common.colors.black};
+	}
+	& > ul:first-of-type {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+		width: 380px;
+	}
+	& > ul:last-of-type {
+		width: 100%;
+		margin-top: 20px;
+		color: ${Common.colors.black};
+		li {
+			margin-bottom: 10px;
+			display: flex;
+			justify-content: space-between;
+			& > button {
+				background-color: ${Common.colors.emphasize};
+				color: ${Common.colors.white};
+				border: none;
+				border-radius: 5px;
+				margin: 3px 2px;
+			}
+		}
+
+		& > :first-of-type {
+			flex-direction: row-reverse;
+		}
+	}
+`;
+
+const UserImageWrapper = styled.li`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 5px;
+	& > label {
+		font-size: 16px;
+		font-weight: ${Common.font.weight.bold};
+		color: ${Common.colors.black};
+	}
+	& > div {
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
+
+		input[placeholder="첨부파일"] {
+			vertical-align: middle;
+			background-color: ${Common.colors.gray2};
+			border: 1px solid ${Common.colors.gray};
+			color: ${Common.colors.gray};
+			border-radius: 10px;
+			width: 78%;
+			padding: 0 10px;
+		}
+
+		label {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			padding: 0 10px;
+			cursor: pointer;
+			background-color: ${Common.colors.emphasize};
+			color: ${Common.colors.white};
+			font-size: ${Common.font.size.sm};
+			border-radius: 10px;
+		}
+
+		input[type="file"] {
+			position: absolute;
+			width: 0;
+			height: 0;
+			padding: 0;
+			overflow: hidden;
+			border: 0;
+		}
+	}
+`;
+
+const UserImage = styled.img`
+	width: 100px;
+	height: 100px;
+	border-radius: 50%;
+`;
+
+const StyledCheckbox = styled(Checkbox)`
+	margin: 0;
+	padding: 0;
+`;
+
+const Submit = styled.button`
+	width: 383px;
+	height: 55px;
+
+	background: ${Common.colors.emphasize};
+	border-radius: 10px;
+	border: none;
+
+	font-weight: ${Common.font.weight.bold};
+	font-size: ${Common.font.size.lg};
+	color: ${Common.colors.white}};
+
+	padding: 15px 32px;
+`;
+
+const Cancle = styled(Link)`
+	:visited {
+		color: inherit;
+	}
+`;
 
 function UserEdit() {
 	const [userData, setUserData] = useState({
@@ -23,6 +181,7 @@ function UserEdit() {
 	const navigate = useNavigate();
 	const userId = localStorage.getItem("_id");
 	const accessToken = localStorage.getItem("accessToken");
+	const [uploadedFileName, setUploadedFileName] = useState("");
 
 	// 비로그인 상태 체크
 	useRequireAuth();
@@ -125,6 +284,7 @@ function UserEdit() {
 	async function handleImageUpload(event: React.ChangeEvent<HTMLInputElement>) {
 		if (event.target.files && event.target.files.length > 0) {
 			const file = event.target.files[0];
+			setUploadedFileName(file.name); // 업로드한 파일의 이름을 상태에 저장
 			const formData = new FormData();
 			formData.append("attach", file); // 'attach' 필드에 파일 추가
 
@@ -155,100 +315,136 @@ function UserEdit() {
 	}
 
 	return (
-		<section>
+		<Backgroud>
 			<Helmet>
 				<title>Edit User - 모두의 오디오 MODI</title>
 			</Helmet>
-			<h2>회원정보 수정</h2>
-			<form onSubmit={handleSubmit}>
-				<ul>
-					{/* 프로필 이미지 수정 */}
-					<li>
-						<img
-							src={userData.extra.profileImage || "../../public/user.svg"}
-							alt="프로필 이미지"
-						/>
-						<label htmlFor="userProfileImage">프로필 이미지</label>
-						<input
-							type="file"
-							accept="image/*"
-							id="userProfileImage"
-							onChange={handleImageUpload}
-						/>
-					</li>
-					<li>
-						<label htmlFor="name">이름</label>
-						<input
-							type="text"
-							id="name"
-							value={userData.name}
-							onChange={handleInputChange}
-						/>
-					</li>
-					<li>
-						<label htmlFor="email">이메일</label>
-						<input
-							type="email"
-							id="email"
-							value={userData.email}
-							onChange={handleInputChange}
-						/>
-					</li>
-					<li>
-						<label htmlFor="password">비밀번호</label>
-						<input
-							type="password"
-							id="password"
-							value={userData.password}
-							onChange={handleInputChange}
-						/>
-					</li>
-					<li>
-						<label htmlFor="confirmPassword">비밀번호 확인</label>
-						<input
-							type="password"
-							id="confirmPassword"
-							value={userData.confirmPassword}
-							onChange={handleInputChange}
-						/>
-					</li>
-					<li>
-						<label htmlFor="phone">휴대폰 번호</label>
-						<input
-							type="text"
-							id="phone"
-							value={userData.phone}
-							onChange={handleInputChange}
-						/>
-					</li>
-				</ul>
-				<ul>
-					<li>
-						<input
-							type="checkbox"
-							id="recievingMarketingInformation"
-							checked={!!userData.extra.terms.recievingMarketingInformation}
-							onChange={handleInputChange}
-						/>
-						<label htmlFor="recievingMarketingInformation">
-							마케팅 정보 수신 동의
-						</label>
-						<button type="button">약관보기</button>
-					</li>
-					<li>
-						<input
-							type="checkbox"
-							id="confirmAge"
-							checked={!!userData.extra.terms.confirmAge}
-							onChange={handleInputChange}
-						/>
-						<label htmlFor="confirmAge">본인은 만 14세 이상입니다.</label>
-					</li>
-				</ul>
-				<Link to="/mypage">수정취소</Link>
-				<button type="submit">수정하기</button>
-			</form>
-		</section>
+			<Title>회원정보 수정</Title>
+			<Form onSubmit={handleSubmit}>
+				<Fieldset>
+					<legend>회원정보 수정</legend>
+
+					<ul>
+						{/* 프로필 이미지 수정 */}
+						<UserImageWrapper>
+							<UserImage
+								src={userData.extra.profileImage || "../../public/user.svg"}
+								alt="프로필 이미지"
+							/>
+							<label htmlFor="userProfileImage">프로필 이미지</label>
+							<div>
+								<input
+									value={uploadedFileName || "첨부파일"}
+									placeholder="첨부파일"
+									readOnly={true}
+								/>
+								<label htmlFor="userProfileImage">파일찾기</label>
+								<input
+									type="file"
+									accept="image/*"
+									id="userProfileImage"
+									onChange={handleImageUpload}
+								/>
+							</div>
+						</UserImageWrapper>
+						<li>
+							<AuthInput
+								id="name"
+								name="name"
+								type="text"
+								defaultValue={userData.name}
+								onChange={handleInputChange}
+								placeholder="이름을 입력하세요"
+								required={true}
+							/>
+						</li>
+						<li>
+							<AuthInput
+								id="email"
+								name="email"
+								type="email"
+								defaultValue={userData.email}
+								onChange={handleInputChange}
+								placeholder="이메일 주소를 입력하세요"
+								required={true}
+								readonly={true}
+							/>
+						</li>
+						<li>
+							<AuthInput
+								id="password"
+								name="password"
+								type="password"
+								onChange={handleInputChange}
+								placeholder="비밀번호를 입력하세요"
+							/>
+						</li>
+						<li>
+							<AuthInput
+								id="confirmPassword"
+								name="confirmPassword"
+								type="password"
+								onChange={handleInputChange}
+								placeholder="비밀번호 확인"
+							/>
+						</li>
+						<li>
+							<AuthInput
+								id="phone"
+								name="phone"
+								type="text"
+								defaultValue={userData.phone}
+								onChange={handleInputChange}
+								placeholder="전화번호를 입력하세요"
+							/>
+						</li>
+					</ul>
+					<ul>
+						<li>
+							<button type="button">약관보기</button>
+							<div>
+								<StyledCheckbox
+									id="recievingMarketingInformation"
+									checked={!!userData.extra.terms.recievingMarketingInformation}
+									onChange={handleInputChange}
+									icon={<CheckCircleOutlineIcon />}
+									checkedIcon={<CheckCircleIcon />}
+									sx={{
+										color: Common.colors.gray,
+										"&.Mui-checked": {
+											color: Common.colors.emphasize,
+										},
+									}}
+								/>
+								<label htmlFor="recievingMarketingInformation">
+									마케팅 정보 수신 동의
+								</label>
+							</div>
+						</li>
+						<li>
+							<div>
+								<StyledCheckbox
+									id="confirmAge"
+									checked={!!userData.extra.terms.confirmAge}
+									onChange={handleInputChange}
+									icon={<CheckCircleOutlineIcon />}
+									checkedIcon={<CheckCircleIcon />}
+									sx={{
+										color: Common.colors.gray,
+										"&.Mui-checked": {
+											color: Common.colors.emphasize,
+										},
+									}}
+								/>
+								<label htmlFor="confirmAge">본인은 만 14세 이상입니다.</label>
+							</div>
+						</li>
+					</ul>
+				</Fieldset>
+				<Submit type="submit">수정하기</Submit>
+				<Cancle to="/mypage">수정취소</Cancle>
+			</Form>
+		</Backgroud>
 	);
 }
 

--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -3,13 +3,13 @@ import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { Common } from "@/styles/common";
 import { axiosInstance } from "@/utils";
 import styled from "@emotion/styled";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import Checkbox from "@mui/material/Checkbox";
 import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast from "react-hot-toast";
 import { Link, useNavigate } from "react-router-dom";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 
 const Title = styled.h2`
 	${Common.a11yHidden};

--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -358,7 +358,11 @@ function UserEdit() {
 								required={true}
 							/>
 						</li>
-						<li>
+						<li
+							onClick={() =>
+								toast("이메일은 수정 불가능합니다.", { duration: 2000 })
+							}
+						>
 							<AuthInput
 								id="email"
 								name="email"

--- a/open-market/src/routes.tsx
+++ b/open-market/src/routes.tsx
@@ -1,20 +1,20 @@
 import RootLayout from "@/layout/RootLayout";
-import ProductDetail from "@/pages/product/ProductDetail";
 import Index from "@/pages/Index";
-import MyPage from "@/pages/user/MyPage";
+import ProductDetail from "@/pages/product/ProductDetail";
 import ProductEdit from "@/pages/product/ProductEdit";
 import ProductManage from "@/pages/product/ProductManage";
-import ProductRegistration from "@/pages/product/ProductRegistration";
 import ProductPurchase from "@/pages/product/ProductPurchase";
+import ProductRegistration from "@/pages/product/ProductRegistration";
+import MyPage from "@/pages/user/MyPage";
 import SignIn from "@/pages/user/SignIn";
 import SignUp from "@/pages/user/SignUp";
+import UserEdit from "@/pages/user/UserEdit";
 import UserOrders from "@/pages/user/UserOrders";
 import UserProducts from "@/pages/user/UserProducts";
-import UserEdit from "@/pages/user/UserEdit";
 import {
-	Route,
-	createBrowserRouter,
-	createRoutesFromElements,
+    Route,
+    createBrowserRouter,
+    createRoutesFromElements,
 } from "react-router-dom";
 
 const router = createBrowserRouter(


### PR DESCRIPTION
<!-- 
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X 
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->


## 작업사항
<!-- 작업한 내용 작성 -->
- 회원정보 수정 페이지 스타일링
- 회원 프로필 업로드 부분 업로드시 해당 파일의 경로 표시되게끔 기능 추가.

## 미리보기 및 사용방법
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
![Dec-15-2023 14-34-04](https://github.com/techitPlus-FE-team3/open_market_projerct/assets/69342971/4edce5f5-a2fc-48a5-85af-8acb039affae)


## 기타
<!-- 필요한 경우 작성 -->
- 계정 이메일(아이디) 수정의 경우 중복 확인 로직을 넣기보단 수정을 막는 방향이 적절할 것으로 판단하여 readonly 속성 부여
- 이메일 영역 클릭시 '이메일은 수정 불가합니다.'라는 토스트 알림이 뜨게끔 설정
- 현재 전화번호 수정의 경우 유효하지 않은 값을 넣어도 수정이 되는 문제가 있음.
- API 상에서 아직 기능이 구현되지 않은 것으로 보임.
- 프로필 이미지 업로드는 가능하지만 프로필 이미지 삭제 기능은 아직 구현되지 않음, 추가 논의 필요.


## 작성일
<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->
2023.12.15
