### PR TITLE
♻️[Refactor] currentUser, category 전역 상태 관리로 수정 #273 

### DIFF
--- a/open-market/package-lock.json
+++ b/open-market/package-lock.json
@@ -28,6 +28,7 @@
         "react-query": "^3.39.3",
         "react-router-dom": "^6.19.0",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "vite-plugin-svgr": "^4.2.0"
       },
       "devDependencies": {
@@ -7583,6 +7584,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/open-market/package.json
+++ b/open-market/package.json
@@ -30,6 +30,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.19.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "vite-plugin-svgr": "^4.2.0"
   },
   "devDependencies": {

--- a/open-market/src/App.tsx
+++ b/open-market/src/App.tsx
@@ -4,15 +4,33 @@ import { RouterProvider } from "react-router-dom";
 import router from "./routes";
 import { Common } from "./styles/common";
 
+import { codeState } from "@/states/categoryState";
+import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { useSetRecoilState } from "recoil";
+import { axiosInstance } from "./utils";
 
 const queryClient = new QueryClient();
 
 function App() {
+	const setCode = useSetRecoilState(codeState);
+
 	const helmetContext: { helmet: HelmetServerState } = {
 		helmet: {} as HelmetServerState,
 	};
 
+	useEffect(() => {
+		(async () => {
+			try {
+				const response = await axiosInstance.get(`/codes/productCategory`);
+				const responseData = response.data.item;
+				const categoryCodeList = responseData.productCategory.codes;
+				setCode(categoryCodeList);
+			} catch (error) {
+				console.error("상품 리스트 조회 실패:", error);
+			}
+		})();
+	});
 	return (
 		<QueryClientProvider client={queryClient}>
 			<HelmetProvider context={helmetContext}>

--- a/open-market/src/App.tsx
+++ b/open-market/src/App.tsx
@@ -1,14 +1,10 @@
 import { Global, css } from "@emotion/react";
-import { useEffect } from "react";
 import { HelmetProvider, HelmetServerState } from "react-helmet-async";
 import { RouterProvider } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
 import router from "./routes";
 import { Common } from "./styles/common";
 
 import { QueryClient, QueryClientProvider } from "react-query";
-
-import { loggedInState } from "@/states/authState";
 
 const queryClient = new QueryClient();
 
@@ -16,13 +12,6 @@ function App() {
 	const helmetContext: { helmet: HelmetServerState } = {
 		helmet: {} as HelmetServerState,
 	};
-
-	const setLoggedIn = useSetRecoilState(loggedInState);
-
-	useEffect(() => {
-		const token = localStorage.getItem("accessToken");
-		setLoggedIn(!!token);
-	}, [setLoggedIn]);
 
 	return (
 		<QueryClientProvider client={queryClient}>

--- a/open-market/src/components/ProductDetailBadgeComponent.tsx
+++ b/open-market/src/components/ProductDetailBadgeComponent.tsx
@@ -95,13 +95,11 @@ const NoUserPurchaseButton = styled(ProductExtraBadgeStyle)`
 function ProductDetailExtraLink({
 	product,
 	order,
-	loggedIn,
-	logState,
+	currentUser,
 }: {
 	product: Product | undefined;
 	order: Order[] | undefined;
-	loggedIn: boolean;
-	logState: number | undefined;
+	currentUser: CurrentUser | null;
 }) {
 	const navigate = useNavigate();
 
@@ -119,18 +117,18 @@ function ProductDetailExtraLink({
 					북마크
 					{product?.bookmarks ? product?.bookmarks.length : 0}
 				</BookmarkButton>
-				{!loggedIn ? (
+				{!currentUser ? (
 					<NoUserPurchaseButton type="button" onClick={handelSignIn}>
 						<CheckIcon />
 						구매하기
 						{product?.buyQuantity ? product?.buyQuantity : 0}
 					</NoUserPurchaseButton>
-				) : loggedIn && logState === product?.seller_id ? (
+				) : currentUser && currentUser._id === product?.seller_id ? (
 					<ProductExtraLink to={`/productmanage/${product?._id}`}>
 						<CheckIcon />
 						상품 관리
 					</ProductExtraLink>
-				) : (loggedIn && order?.length === 0) || order === undefined ? (
+				) : (currentUser && order?.length === 0) || order === undefined ? (
 					<ProductExtraLink to={`/productpurchase/${product?._id}`}>
 						<CheckIcon />
 						구매하기

--- a/open-market/src/interfaces/user.d.ts
+++ b/open-market/src/interfaces/user.d.ts
@@ -26,3 +26,9 @@ interface UserResponse {
 	ok: number;
 	item: User;
 }
+
+interface CurrentUser {
+	_id: number;
+	name: string;
+	profileImage: string | null;
+}

--- a/open-market/src/layout/Header.tsx
+++ b/open-market/src/layout/Header.tsx
@@ -149,7 +149,7 @@ const Header = () => {
 	);
 	const [__, setCategoryFilter] = useRecoilState<string>(categoryKeywordState);
 
-	const currentUser = useRecoilValue(currentUserState);
+	const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
 
 	const navigate = useNavigate();
 
@@ -188,7 +188,9 @@ const Header = () => {
 	}
 
 	function handleLogout() {
-		localStorage.clear();
+		setCurrentUser(null);
+		localStorage.removeItem('accessToken');
+		localStorage.removeItem('refreshToken');
 		sessionStorage.clear();
 
 		toast.success(`로그아웃 되었습니다.`);

--- a/open-market/src/layout/Header.tsx
+++ b/open-market/src/layout/Header.tsx
@@ -21,7 +21,7 @@ import {
 } from "@mui/material";
 import { KeyboardEvent, useEffect, useState } from "react";
 
-import { loggedInState } from "@/states/authState";
+import { currentUserState } from "@/states/authState";
 import {
 	categoryKeywordState,
 	fetchProductListState,
@@ -149,7 +149,8 @@ const Header = () => {
 	);
 	const [__, setCategoryFilter] = useRecoilState<string>(categoryKeywordState);
 
-	const [loggedIn, setLoggedIn] = useRecoilState(loggedInState);
+	const currentUser = useRecoilValue(currentUserState);
+
 	const navigate = useNavigate();
 
 	const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -189,7 +190,6 @@ const Header = () => {
 	function handleLogout() {
 		localStorage.clear();
 		sessionStorage.clear();
-		setLoggedIn(false);
 
 		toast.success(`로그아웃 되었습니다.`);
 		navigate("/");
@@ -276,7 +276,7 @@ const Header = () => {
 					}}
 					sx={{ m: 2 }}
 				/>
-				{loggedIn && (
+				{currentUser && (
 					<ButtonWrapper>
 						<UploadButton
 							startIcon={<FileUpload />}
@@ -327,7 +327,7 @@ const Header = () => {
 						</Menu>
 					</ButtonWrapper>
 				)}
-				{!loggedIn && (
+				{!currentUser && (
 					<ButtonWrapper>
 						<UserButton onClick={handleProfileMenuOpen}>
 							<AccountCircle />

--- a/open-market/src/pages/Index.tsx
+++ b/open-market/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ProductListComponent";
 import { ProductListItem } from "@/components/ProductListItem";
 import SearchBar from "@/components/SearchBar";
+import { codeState } from "@/states/categoryState";
 import {
 	categoryKeywordState,
 	fetchProductListState,
@@ -18,11 +19,7 @@ import {
 	searchKeywordState,
 	searchedProductListState,
 } from "@/states/productListState";
-import {
-	axiosInstance,
-	categoryFilterProductList,
-	searchProductList,
-} from "@/utils";
+import { categoryFilterProductList, searchProductList } from "@/utils";
 import styled from "@emotion/styled";
 import { useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
@@ -45,17 +42,19 @@ const BannerSection = styled.section<bannerProps>`
 function Index() {
 	const searchRef = useRef<HTMLInputElement>(null);
 	const [limit, setLimit] = useState(4);
+
 	const fetchedProductList = useRecoilValue(fetchProductListState(limit));
+	const category = useRecoilValue(codeState);
+
 	const [productList, setProductList] = useRecoilState(productListState);
 	const [searchKeyword, setSearchKeyword] =
 		useRecoilState<string>(searchKeywordState);
 	const [searchedProductList, setSearchedProductList] = useRecoilState<
 		Product[]
 	>(searchedProductListState);
-
-	const [category, setCategory] = useState<CategoryCode[]>();
 	const [categoryFilter, setCategoryFilter] =
 		useRecoilState<string>(categoryKeywordState);
+
 	const [filteredProductList, setFilteredProductList] = useState<Product[]>();
 
 	function handleSearchKeyword() {
@@ -66,36 +65,10 @@ function Index() {
 
 	useEffect(() => {
 		setProductList(fetchedProductList!);
-
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`);
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-			} catch (error) {
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
 	}, [limit]);
 
 	useEffect(() => {
 		setProductList(fetchedProductList!);
-
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`);
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-			} catch (error) {
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
 	}, []);
 
 	useEffect(() => {
@@ -104,7 +77,7 @@ function Index() {
 				return value;
 			}
 			if (value !== undefined && category !== undefined) {
-				return category.find((item) => item.value === value)?.code;
+				return category?.find((item) => item.value === value)?.code;
 			}
 		}
 

--- a/open-market/src/pages/product/ProductDetail.tsx
+++ b/open-market/src/pages/product/ProductDetail.tsx
@@ -9,6 +9,7 @@ import ReplyListItem, {
 	ReplyUserProfileImage,
 } from "@/components/ReplyComponent";
 import { currentUserState } from "@/states/authState";
+import { codeState } from "@/states/categoryState";
 import { axiosInstance, debounce, formatDate } from "@/utils";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import ModeCommentIcon from "@mui/icons-material/ModeComment";
@@ -25,6 +26,7 @@ function ProductDetail() {
 	const { productId } = useParams();
 
 	const currentUser = useRecoilValue(currentUserState);
+	const category = useRecoilValue(codeState);
 
 	const replyRef = useRef<HTMLTextAreaElement & HTMLDivElement>(null);
 
@@ -34,7 +36,6 @@ function ProductDetail() {
 	const [ratingValue, setRatingValue] = useState<number>(3);
 	const [_, setHover] = useState(-1);
 	const [replyContent, setReplyContent] = useState<string>();
-	const [category, setCategory] = useState<CategoryCode[]>();
 	const [genre, setGenre] = useState<string>();
 	const [createdAt, setCreatedAt] = useState<string>();
 
@@ -124,21 +125,6 @@ function ProductDetail() {
 	}, []);
 
 	useEffect(() => {
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`);
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-			} catch (error) {
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
-	}, []);
-
-	useEffect(() => {
 		getProduct(productId!);
 		if (currentUser) {
 			getOrder(Number(productId)!);
@@ -168,7 +154,7 @@ function ProductDetail() {
 				category !== undefined &&
 				product !== undefined
 			) {
-				return category.find((item) => item.code === code)?.value;
+				return category?.find((item) => item.code === code)?.value;
 			}
 		}
 		setGenre(translateCodeToValue(product?.extra?.category!));

--- a/open-market/src/pages/product/ProductEdit.tsx
+++ b/open-market/src/pages/product/ProductEdit.tsx
@@ -4,6 +4,7 @@ import SelectGenre from "@/components/SelectGenre";
 import Textarea from "@/components/Textarea";
 import UploadLoadingSpinner from "@/components/UploadLoadingSpinner";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { codeState } from "@/states/categoryState";
 import { Common } from "@/styles/common";
 import { axiosInstance, debounce } from "@/utils";
 import { uploadFile } from "@/utils/uploadFile";
@@ -17,6 +18,7 @@ import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast, { Renderable, Toast, ValueFunction } from "react-hot-toast";
 import { useNavigate, useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 interface FlexLayoutProps {
 	right?: boolean;
@@ -170,8 +172,10 @@ function ProductEdit() {
 	const navigate = useNavigate();
 
 	const { productId } = useParams();
+
+	const category = useRecoilValue(codeState);
+
 	const [userProductInfo, setUserProductInfo] = useState<Product>();
-	const [category, setCategory] = useState<CategoryCode[]>();
 	const [postItem, setPostItem] = useState<ProductEditForm>({
 		show: false,
 		name: "",
@@ -286,25 +290,6 @@ function ProductEdit() {
 				console.error("상품 정보 조회 실패:", error);
 			}
 		};
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`, {
-					headers: {
-						Authorization: `Bearer ${accessToken}`,
-					},
-				});
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-
-				// 데이터를 로컬 스토리지에 저장
-			} catch (error) {
-				// 에러 처리
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
 		fetchUserProductInfo();
 	}, [productId]);
 
@@ -373,7 +358,7 @@ function ProductEdit() {
 										extra: { ...postItem.extra, category: e.target.value },
 									});
 								}}
-								category={category}
+								category={category!}
 							/>
 							<FormInput
 								name="hashTag"

--- a/open-market/src/pages/product/ProductManage.tsx
+++ b/open-market/src/pages/product/ProductManage.tsx
@@ -2,6 +2,7 @@ import FunctionalButton from "@/components/FunctionalButton";
 import Textarea from "@/components/Textarea";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { currentUserState } from "@/states/authState";
+import { codeState } from "@/states/categoryState";
 import { Common } from "@/styles/common";
 import { axiosInstance, numberWithComma } from "@/utils";
 import styled from "@emotion/styled";
@@ -161,8 +162,8 @@ function ProductManage() {
 	const navigate = useNavigate();
 	const { productId } = useParams();
 	const currentUser = useRecoilValue(currentUserState);
+	const category = useRecoilValue(codeState);
 	const [userProductInfo, setUserProductInfo] = useState<Product>();
-	const [category, setCategory] = useState<CategoryCode[]>();
 	const [genre, setGenre] = useState<string>();
 
 	// 비로그인 상태 체크
@@ -220,28 +221,13 @@ function ProductManage() {
 	}, []);
 
 	useEffect(() => {
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`);
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-			} catch (error) {
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
-	}, []);
-
-	useEffect(() => {
 		function translateCodeToValue(code: string) {
 			if (
 				code !== undefined &&
 				category !== undefined &&
 				userProductInfo !== undefined
 			) {
-				return category.find((item) => item.code === code)?.value;
+				return category!.find((item) => item.code === code)?.value;
 			}
 		}
 		setGenre(translateCodeToValue(userProductInfo?.extra?.category!));

--- a/open-market/src/pages/product/ProductManage.tsx
+++ b/open-market/src/pages/product/ProductManage.tsx
@@ -1,6 +1,7 @@
 import FunctionalButton from "@/components/FunctionalButton";
 import Textarea from "@/components/Textarea";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { currentUserState } from "@/states/authState";
 import { Common } from "@/styles/common";
 import { axiosInstance, numberWithComma } from "@/utils";
 import styled from "@emotion/styled";
@@ -14,6 +15,7 @@ import { Helmet } from "react-helmet-async";
 
 import toast from "react-hot-toast";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 interface FlexLayoutProps {
 	right?: boolean;
@@ -158,6 +160,7 @@ const LinkedEditButton = styled(Link)`
 function ProductManage() {
 	const navigate = useNavigate();
 	const { productId } = useParams();
+	const currentUser = useRecoilValue(currentUserState);
 	const [userProductInfo, setUserProductInfo] = useState<Product>();
 	const [category, setCategory] = useState<CategoryCode[]>();
 	const [genre, setGenre] = useState<string>();
@@ -168,7 +171,6 @@ function ProductManage() {
 	function handleProductDelete(e: { preventDefault: () => void }) {
 		e.preventDefault();
 		const accessToken = localStorage.getItem("accessToken");
-		const userId = localStorage.getItem("_id");
 		const result = confirm("상품을 정말로 삭제하시겠습니까?");
 		if (!result) return;
 		try {
@@ -185,7 +187,7 @@ function ProductManage() {
 							"aria-live": "polite",
 						},
 					});
-					navigate(`/user/${userId}/products`);
+					navigate(`/user/${currentUser?._id}/products`);
 				})
 				.catch((error) => {
 					console.error("에러 발생:", error);

--- a/open-market/src/pages/product/ProductPurchase.tsx
+++ b/open-market/src/pages/product/ProductPurchase.tsx
@@ -1,6 +1,7 @@
 import FunctionalButton from "@/components/FunctionalButton";
 import Textarea from "@/components/Textarea";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { codeState } from "@/states/categoryState";
 import { Common } from "@/styles/common";
 import { axiosInstance, numberWithComma } from "@/utils";
 import styled from "@emotion/styled";
@@ -8,6 +9,7 @@ import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast from "react-hot-toast";
 import { useNavigate, useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 interface FlexLayoutProps {
 	right?: boolean;
@@ -126,8 +128,8 @@ const ContentWrapper = styled.div`
 function ProductPurchase() {
 	const navigate = useNavigate();
 	const { productId } = useParams();
+	const category = useRecoilValue(codeState);
 	const [product, setProduct] = useState<Product>();
-	const [category, setCategory] = useState<CategoryCode[]>();
 	const [genre, setGenre] = useState<string>();
 
 	//비로그인 상태 체크
@@ -182,28 +184,13 @@ function ProductPurchase() {
 	}, []);
 
 	useEffect(() => {
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`);
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-			} catch (error) {
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
-	}, []);
-
-	useEffect(() => {
 		function translateCodeToValue(code: string) {
 			if (
 				code !== undefined &&
 				category !== undefined &&
 				product !== undefined
 			) {
-				return category.find((item) => item.code === code)?.value;
+				return category!.find((item) => item.code === code)?.value;
 			}
 		}
 		setGenre(translateCodeToValue(product?.extra?.category!));

--- a/open-market/src/pages/product/ProductRegistration.tsx
+++ b/open-market/src/pages/product/ProductRegistration.tsx
@@ -15,7 +15,7 @@ import FileUploadIcon from "@mui/icons-material/FileUpload";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { Radio, RadioProps } from "@mui/material";
 import { styled as muiStyled } from "@mui/system";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast, { Renderable, Toast, ValueFunction } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";

--- a/open-market/src/pages/product/ProductRegistration.tsx
+++ b/open-market/src/pages/product/ProductRegistration.tsx
@@ -4,6 +4,7 @@ import SelectGenre from "@/components/SelectGenre";
 import Textarea from "@/components/Textarea";
 import UploadLoadingSpinner from "@/components/UploadLoadingSpinner";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { codeState } from "@/states/categoryState";
 import { Common } from "@/styles/common";
 import { axiosInstance, debounce } from "@/utils";
 import { uploadFile } from "@/utils/uploadFile";
@@ -17,6 +18,7 @@ import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast, { Renderable, Toast, ValueFunction } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 interface FlexLayoutProps {
 	right?: boolean;
@@ -173,6 +175,8 @@ const StyledRadio = muiStyled((props: RadioProps) => (
 function ProductRegistration() {
 	const navigate = useNavigate();
 
+	const category = useRecoilValue(codeState);
+
 	const [sellerName, setSellerName] = useState<string>("");
 	const [postItem, setPostItem] = useState<ProductRegistForm>({
 		show: true,
@@ -193,7 +197,7 @@ function ProductRegistration() {
 			soundFile: { path: "", name: "", originalname: "" },
 		},
 	});
-	const [category, setCategory] = useState<CategoryCode[]>();
+
 	const [imageLoading, setImageLoading] = useState<boolean>(false);
 	const [audioLoading, setAudioLoading] = useState<boolean>(false);
 
@@ -263,30 +267,6 @@ function ProductRegistration() {
 			navigate(-1);
 		}
 	}
-
-	useEffect(() => {
-		const accessToken = localStorage.getItem("accessToken");
-
-		async function fetchCategory() {
-			try {
-				const response = await axiosInstance.get(`/codes/productCategory`, {
-					headers: {
-						Authorization: `Bearer ${accessToken}`,
-					},
-				});
-				const responseData = response.data.item;
-				const categoryCodeList = responseData.productCategory.codes;
-				setCategory(categoryCodeList);
-
-				// 데이터를 로컬 스토리지에 저장
-			} catch (error) {
-				// 에러 처리
-				console.error("상품 리스트 조회 실패:", error);
-			}
-		}
-
-		fetchCategory();
-	}, []);
 
 	useEffect(() => {
 		setPostItem({
@@ -359,7 +339,7 @@ function ProductRegistration() {
 										extra: { ...postItem.extra, category: e.target.value },
 									});
 								}}
-								category={category}
+								category={category!}
 							/>
 							<FormInput
 								name="hashTag"

--- a/open-market/src/pages/product/ProductRegistration.tsx
+++ b/open-market/src/pages/product/ProductRegistration.tsx
@@ -4,6 +4,7 @@ import SelectGenre from "@/components/SelectGenre";
 import Textarea from "@/components/Textarea";
 import UploadLoadingSpinner from "@/components/UploadLoadingSpinner";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { currentUserState } from "@/states/authState";
 import { codeState } from "@/states/categoryState";
 import { Common } from "@/styles/common";
 import { axiosInstance, debounce } from "@/utils";
@@ -176,8 +177,8 @@ function ProductRegistration() {
 	const navigate = useNavigate();
 
 	const category = useRecoilValue(codeState);
+	const currentUser = useRecoilValue(currentUserState);
 
-	const [sellerName, setSellerName] = useState<string>("");
 	const [postItem, setPostItem] = useState<ProductRegistForm>({
 		show: true,
 		active: true,
@@ -189,7 +190,7 @@ function ProductRegistration() {
 		quantity: Number.MAX_SAFE_INTEGER,
 		buyQuantity: 0,
 		extra: {
-			sellerName: "",
+			sellerName: currentUser?.name!,
 			isNew: true,
 			isBest: false,
 			category: "",
@@ -267,13 +268,6 @@ function ProductRegistration() {
 			navigate(-1);
 		}
 	}
-
-	useEffect(() => {
-		setPostItem({
-			...postItem,
-			extra: { ...postItem.extra, sellerName: sellerName },
-		});
-	}, [sellerName]);
 
 	return (
 		<ProductRegistSection>

--- a/open-market/src/pages/product/ProductRegistration.tsx
+++ b/open-market/src/pages/product/ProductRegistration.tsx
@@ -200,20 +200,6 @@ function ProductRegistration() {
 	//비로그인 상태 체크
 	useRequireAuth();
 
-	async function getUser(id: number) {
-		const accessToken = localStorage.getItem("accessToken");
-		try {
-			const response = await axiosInstance.get<UserResponse>(`/users/${id}`, {
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-				},
-			});
-			setSellerName(response.data.item.name);
-		} catch (err) {
-			console.error(err);
-		}
-	}
-
 	function handlePostProductRegist(e: { preventDefault: () => void }) {
 		e.preventDefault();
 		const accessToken = localStorage.getItem("accessToken");
@@ -280,7 +266,6 @@ function ProductRegistration() {
 
 	useEffect(() => {
 		const accessToken = localStorage.getItem("accessToken");
-		const userId = localStorage.getItem("_id");
 
 		async function fetchCategory() {
 			try {
@@ -301,7 +286,6 @@ function ProductRegistration() {
 		}
 
 		fetchCategory();
-		getUser(+userId!);
 	}, []);
 
 	useEffect(() => {

--- a/open-market/src/pages/user/MyPage.tsx
+++ b/open-market/src/pages/user/MyPage.tsx
@@ -1,5 +1,6 @@
 import MyPageList from "@/components/MyPageList";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { currentUserState } from "@/states/authState";
 import { Common } from "@/styles/common";
 import { axiosInstance } from "@/utils";
 import styled from "@emotion/styled";
@@ -7,6 +8,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 const Section = styled.section`
 	width: 1440px;
@@ -156,7 +158,7 @@ function MyPage() {
 
 	const [bookmarkDetails, setBookmarkDetails] = useState<any[]>([]);
 
-	const userId = localStorage.getItem("_id");
+	const currentUser = useRecoilValue(currentUserState);
 	const accessToken = localStorage.getItem("accessToken");
 	const historyList = JSON.parse(
 		sessionStorage.getItem("historyList") as string,
@@ -169,7 +171,7 @@ function MyPage() {
 		async function fetchUserInfo() {
 			try {
 				const response = await axiosInstance.get<UserResponse>(
-					`/users/${userId}`,
+					`/users/${currentUser!._id}`,
 					{
 						headers: {
 							Authorization: `Bearer ${accessToken}`,
@@ -266,7 +268,9 @@ function MyPage() {
 								<p>{userInfo.phone}</p>
 							</div>
 						</PersonalInfoItem>
-						<StyledLink to={`/useredit/${userId}`}>회원정보 수정</StyledLink>
+						<StyledLink to={`/useredit/${currentUser!._id}`}>
+							회원정보 수정
+						</StyledLink>
 					</PersonalInfo>
 					<Comment>
 						<Title>내가 쓴 댓글</Title>
@@ -335,7 +339,7 @@ function MyPage() {
 					</Link>
 				)}
 				linkText="전체보기"
-				linkUrl={`/user/${userId}/products`}
+				linkUrl={`/user/${currentUser!._id}/products`}
 			/>
 		</Section>
 	);

--- a/open-market/src/pages/user/MyPage.tsx
+++ b/open-market/src/pages/user/MyPage.tsx
@@ -155,7 +155,7 @@ const Image = styled.img`
 // API 호출을 위한 함수
 async function fetchUserInfo(userId: string) {
 	const accessToken = localStorage.getItem("accessToken");
-	const response = await axiosInstance.get(`/users/${currentUser!._id}`, {
+	const response = await axiosInstance.get(`/users/${userId}`, {
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
 		},

--- a/open-market/src/pages/user/UserEdit.tsx
+++ b/open-market/src/pages/user/UserEdit.tsx
@@ -1,5 +1,6 @@
 import AuthInput from "@/components/AuthInput";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
+import { currentUserState } from "@/states/authState";
 import { Common } from "@/styles/common";
 import { axiosInstance } from "@/utils";
 import styled from "@emotion/styled";
@@ -10,6 +11,7 @@ import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import toast from "react-hot-toast";
 import { Link, useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 
 const API_KEY = import.meta.env.VITE_API_SERVER;
 
@@ -181,7 +183,7 @@ function UserEdit() {
 		},
 	});
 	const navigate = useNavigate();
-	const userId = localStorage.getItem("_id");
+	const currentUser = useRecoilValue(currentUserState);
 	const accessToken = localStorage.getItem("accessToken");
 	const [uploadedFileName, setUploadedFileName] = useState("");
 
@@ -192,7 +194,7 @@ function UserEdit() {
 		// 사용자 정보 불러오기
 		async function fetchUserInfo() {
 			try {
-				const response = await axiosInstance.get(`/users/${userId}`, {
+				const response = await axiosInstance.get(`/users/${currentUser?._id}`, {
 					headers: {
 						Authorization: `Bearer ${accessToken}`,
 					},
@@ -222,7 +224,7 @@ function UserEdit() {
 		}
 
 		fetchUserInfo();
-	}, [userId, accessToken]);
+	}, [currentUser, accessToken]);
 
 	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();
@@ -246,11 +248,15 @@ function UserEdit() {
 
 		// 정보 수정 요청
 		try {
-			const response = await axiosInstance.patch(`/users/${userId}`, payload, {
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
+			const response = await axiosInstance.patch(
+				`/users/${currentUser?._id}`,
+				payload,
+				{
+					headers: {
+						Authorization: `Bearer ${accessToken}`,
+					},
 				},
-			});
+			);
 			if (response.data.ok) {
 				toast.success("회원 정보가 수정되었습니다.");
 				navigate("/mypage");

--- a/open-market/src/states/authState.ts
+++ b/open-market/src/states/authState.ts
@@ -1,6 +1,13 @@
 import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
 
-export const loggedInState = atom({
-	key: "loggedInState",
-	default: false,
+const { persistAtom } = recoilPersist({
+	key: "currentUser",
+	storage: localStorage,
+});
+
+export const currentUserState = atom<CurrentUser | null>({
+	key: "currentUserState",
+	default: null,
+	effects: [persistAtom],
 });

--- a/open-market/src/states/categoryState.ts
+++ b/open-market/src/states/categoryState.ts
@@ -1,0 +1,13 @@
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist({
+	key: "code",
+	storage: localStorage,
+});
+
+export const codeState = atom<CategoryCode[] | null>({
+	key: "codeState",
+	default: null,
+	effects: [persistAtom],
+});

--- a/open-market/src/utils/refreshToken.ts
+++ b/open-market/src/utils/refreshToken.ts
@@ -45,9 +45,7 @@ async function refreshToken() {
 function handleTokenRefreshError(error: any) {
 	console.error("Error refreshing token:", error);
 	toast.error("토큰이 만료되었습니다. 다시 로그인해주세요.");
-	localStorage.removeItem("accessToken");
-	localStorage.removeItem("refreshToken");
-	localStorage.removeItem("_id");
+	localStorage.clear();
 }
 
 // 응답 인터셉터 설정


### PR DESCRIPTION
<!-- 
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X 
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->


## 작업사항
<!-- 작업한 내용 작성 -->
- 유저 정보를 필요할 때마다 불러오는 것이 아니라 로그인할 때 정보를 저장하고 그 값을 꺼내쓰는 방식으로 수정
- 카테고리를 페이지마다 호출하는 것이 아니라 전역상태로 관리
- loggedState 부분을 currentUser로 수정
- 카테고리 관련 코드 수정

## 미리보기 및 사용방법
<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
<img width="633" alt="스크린샷 2023-12-20 오후 9 29 38" src="https://github.com/techitPlus-FE-team3/open_market_projerct/assets/43366461/52334589-8293-49b9-ae67-be56f7ebf36b">

## 기타
<!-- 필요한 경우 작성 -->
App.tsx의 import 부분은 한번에 수정 예정


## 작성일
<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->
2023.12.20
